### PR TITLE
Add Sensu Go handler to alert node

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -253,6 +253,7 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 		c := sensugo.HandlerConfig{
 			URL:       s.URL,
 			Entity:    s.Entity,
+			EntityTag: s.EntityTag,
 			Namespace: s.Namespace,
 			Handlers:  s.HandlersList,
 			Labels:    s.LabelMap,

--- a/alert.go
+++ b/alert.go
@@ -27,6 +27,7 @@ import (
 	"github.com/influxdata/kapacitor/services/pagerduty2"
 	"github.com/influxdata/kapacitor/services/pushover"
 	"github.com/influxdata/kapacitor/services/sensu"
+	"github.com/influxdata/kapacitor/services/sensugo"
 	"github.com/influxdata/kapacitor/services/slack"
 	"github.com/influxdata/kapacitor/services/smtp"
 	"github.com/influxdata/kapacitor/services/snmptrap"
@@ -242,6 +243,21 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 			Metadata: s.MetadataMap,
 		}
 		h, err := et.tm.SensuService.Handler(c, ctx...)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create sensu alert handler")
+		}
+		an.handlers = append(an.handlers, h)
+	}
+
+	for _, s := range n.SensuGoHandlers {
+		c := sensugo.HandlerConfig{
+			URL:       s.URL,
+			Entity:    s.Entity,
+			Namespace: s.Namespace,
+			Handlers:  s.HandlersList,
+			Labels:    s.LabelMap,
+		}
+		h, err := et.tm.SensuGoService.Handler(c, ctx...)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create sensu alert handler")
 		}

--- a/alert.go
+++ b/alert.go
@@ -257,6 +257,7 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 			Namespace: s.Namespace,
 			Handlers:  s.HandlersList,
 			Labels:    s.LabelMap,
+			LabelTags: s.LabelTagsMap,
 		}
 		h, err := et.tm.SensuGoService.Handler(c, ctx...)
 		if err != nil {

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1433,6 +1433,15 @@ func (s *SensuGoHandler) Label(key string, value string) *SensuGoHandler {
 	return s
 }
 
+// Label adds key values pairs to the sensu request.
+// tick:property
+func (s *SensuGoHandler) LabelTag(key string, value string) *SensuGoHandler {
+	if s.LabelTagsMap == nil {
+		s.LabelTagsMap = make(map[string]string)
+	}
+	s.LabelTagsMap[key] = value
+	return s
+}
 // Send the alert to Pushover.
 // Register your application with Pushover at
 // https://pushover.net/apps/build to get a

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1412,6 +1412,9 @@ type SensuGoHandler struct {
 
 	// LabelMap is a map of arbitrary label keys and their values
 	LabelMap map[string]string `tick:"Label" json:"label"`
+
+	// LabelTagsMap is a map of arbitrary label keys that map to tag names
+	LabelTagsMap map[string]string `tick:"LabelTag" json:"labelTag"`
 }
 
 // tick:property

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1396,8 +1396,11 @@ type SensuGoHandler struct {
 	// Backend REST API URL
 	URL string `json:"url"`
 
-	// Sensu entity name
+	// Sensu entity name (overrides EntityTag)
 	Entity string `json:"entity"`
+
+	// Name of tag containing Sensu entity name
+	EntityTag string `json:"entityTag"`
 
 	// Sensu Namespace
 	Namespace string `json:"namespace"`

--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -157,6 +157,24 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 		}
 	}
 
+	for _, h := range a.SensuGoHandlers {
+		n.Dot("sensugo").
+			Dot("name", h.Name).
+			Dot("namespace", h.Namespace).
+			Dot("message", h.Message).
+			Dot("handlers", args(h.HandlersList)...)
+
+		// Use stable key order
+		keys := make([]string, 0, len(h.LabelsMap))
+		for k := range h.LabelMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.Dot("label", k, h.LabelsMap[k])
+		}
+	}
+
 	for _, h := range a.SlackHandlers {
 		n.Dot("slack").
 			Dot("workspace", h.Workspace).

--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -173,6 +173,16 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 		for _, k := range keys {
 			n.Dot("label", k, h.LabelsMap[k])
 		}
+
+		// labelTags
+		keys := make([]string, 0, len(h.LabelTagsMap))
+		for k := range h.LabelTagsMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.Dot("labelTag", k, h.LabelTagsMap[k])
+		}
 	}
 
 	for _, h := range a.SlackHandlers {

--- a/pipeline/tick/alert_test.go
+++ b/pipeline/tick/alert_test.go
@@ -470,6 +470,30 @@ func TestAlertSensu(t *testing.T) {
 	PipelineTickTestHelper(t, pipe, want)
 }
 
+func TestAlertSensuGo(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	handler := from.Alert().SensuGo()
+	handler.Handlers("FBI", "Witness", "Protection")
+	handler.LabelMap = map[string]interface{}{
+		"env":  "test",
+		"role": "testrole",
+	}
+
+	want := `stream
+    |from()
+    |alert()
+        .id('{{ .Name }}:{{ .Group }}')
+        .message('{{ .ID }} is {{ .Level }}')
+        .details('{{ json . }}')
+        .history(21)
+        .sensu()
+        .handlers('FBI', 'Witness', 'Protection')
+				.label('env', 'test')
+				.label('role', 'testrole')
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
 func TestAlertSlack(t *testing.T) {
 	pipe, _, from := StreamFrom()
 	handler := from.Alert().Slack()

--- a/server/config.go
+++ b/server/config.go
@@ -42,6 +42,7 @@ import (
 	"github.com/influxdata/kapacitor/services/reporting"
 	"github.com/influxdata/kapacitor/services/scraper"
 	"github.com/influxdata/kapacitor/services/sensu"
+	"github.com/influxdata/kapacitor/services/sensugo"
 	"github.com/influxdata/kapacitor/services/serverset"
 	"github.com/influxdata/kapacitor/services/slack"
 	"github.com/influxdata/kapacitor/services/smtp"
@@ -98,6 +99,7 @@ type Config struct {
 	SMTP       smtp.Config       `toml:"smtp" override:"smtp"`
 	SNMPTrap   snmptrap.Config   `toml:"snmptrap" override:"snmptrap"`
 	Sensu      sensu.Config      `toml:"sensu" override:"sensu"`
+	SensuGo    sensugo.Config    `toml:"sensugo" override:"sensugo"`
 	Slack      slack.Configs     `toml:"slack" override:"slack,element-key=workspace"`
 	Talk       talk.Config       `toml:"talk" override:"talk"`
 	Telegram   telegram.Config   `toml:"telegram" override:"telegram"`
@@ -166,6 +168,7 @@ func NewConfig() *Config {
 	c.HTTPPost = httppost.Configs{httppost.NewConfig()}
 	c.SMTP = smtp.NewConfig()
 	c.Sensu = sensu.NewConfig()
+	c.SensuGo = sensugo.NewConfig()
 	c.Slack = slack.Configs{slack.NewDefaultConfig()}
 	c.Talk = talk.NewConfig()
 	c.SNMPTrap = snmptrap.NewConfig()
@@ -307,6 +310,9 @@ func (c *Config) Validate() error {
 	}
 	if err := c.Sensu.Validate(); err != nil {
 		return errors.Wrap(err, "sensu")
+	}
+	if err := c.SensuGo.Validate(); err != nil {
+		return errors.Wrap(err, "sensugo")
 	}
 	if err := c.Slack.Validate(); err != nil {
 		return errors.Wrap(err, "slack")

--- a/server/server.go
+++ b/server/server.go
@@ -53,6 +53,7 @@ import (
 	"github.com/influxdata/kapacitor/services/reporting"
 	"github.com/influxdata/kapacitor/services/scraper"
 	"github.com/influxdata/kapacitor/services/sensu"
+	"github.com/influxdata/kapacitor/services/sensugo"
 	"github.com/influxdata/kapacitor/services/serverset"
 	"github.com/influxdata/kapacitor/services/servicetest"
 	"github.com/influxdata/kapacitor/services/sideload"
@@ -260,6 +261,7 @@ func New(c *Config, buildInfo BuildInfo, diagService *diagnostic.Service) (*Serv
 	}
 	s.appendSNMPTrapService()
 	s.appendSensuService()
+	s.appendSensuGoService()
 	s.appendTalkService()
 	s.appendVictorOpsService()
 
@@ -690,6 +692,18 @@ func (s *Server) appendSensuService() {
 
 	s.SetDynamicService("sensu", srv)
 	s.AppendService("sensu", srv)
+}
+
+func (s *Server) appendSensuGoService() {
+	c := s.config.SensuGo
+	d := s.DiagService.NewSensuGoHandler()
+	srv := sensugo.NewService(c, d)
+
+	s.TaskMaster.SensuGoService = srv
+	s.AlertService.SensuGoService = srv
+
+	s.SetDynamicService("sensugo", srv)
+	s.AppendService("sensugo", srv)
 }
 
 func (s *Server) appendSlackService() error {

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/influxdata/kapacitor/services/pagerduty2"
 	"github.com/influxdata/kapacitor/services/pushover"
 	"github.com/influxdata/kapacitor/services/sensu"
+	"github.com/influxdata/kapacitor/services/sensugo"
 	"github.com/influxdata/kapacitor/services/slack"
 	"github.com/influxdata/kapacitor/services/smtp"
 	"github.com/influxdata/kapacitor/services/snmptrap"
@@ -113,6 +114,9 @@ type Service struct {
 	}
 	SensuService interface {
 		Handler(sensu.HandlerConfig, ...keyvalue.T) (alert.Handler, error)
+	}
+	SensuGoService interface {
+		Handler(sensugo.HandlerConfig, ...keyvalue.T) (alert.Handler, error)
 	}
 	SlackService interface {
 		Handler(slack.HandlerConfig, ...keyvalue.T) alert.Handler
@@ -898,6 +902,17 @@ func (s *Service) createHandlerFromSpec(spec HandlerSpec) (handler, error) {
 			return handler{}, err
 		}
 		h, err = s.SensuService.Handler(c, ctx...)
+		if err != nil {
+			return handler{}, err
+		}
+		h = newExternalHandler(h)
+	case "sensugo":
+		c := sensugo.HandlerConfig{}
+		err = decodeOptions(spec.Options, &c)
+		if err != nil {
+			return handler{}, err
+		}
+		h, err = s.SensuGoService.Handler(c, ctx...)
 		if err != nil {
 			return handler{}, err
 		}

--- a/services/diagnostic/handlers.go
+++ b/services/diagnostic/handlers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/influxdata/kapacitor/services/pagerduty2"
 	"github.com/influxdata/kapacitor/services/pushover"
 	"github.com/influxdata/kapacitor/services/sensu"
+	"github.com/influxdata/kapacitor/services/sensugo"
 	"github.com/influxdata/kapacitor/services/sideload"
 	"github.com/influxdata/kapacitor/services/slack"
 	"github.com/influxdata/kapacitor/services/smtp"
@@ -787,6 +788,24 @@ func (h *SensuHandler) WithContext(ctx ...keyvalue.T) sensu.Diagnostic {
 	fields := logFieldsFromContext(ctx)
 
 	return &SensuHandler{
+		l: h.l.With(fields...),
+	}
+}
+
+// Sensu Go handler
+
+type SensuGoHandler struct {
+	l Logger
+}
+
+func (h *SensuGoHandler) Error(msg string, err error, ctx ...keyvalue.T) {
+	Err(h.l, msg, err, ctx)
+}
+
+func (h *SensuGoHandler) WithContext(ctx ...keyvalue.T) sensugo.Diagnostic {
+	fields := logFieldsFromContext(ctx)
+
+	return &SensuGoHandler{
 		l: h.l.With(fields...),
 	}
 }

--- a/services/diagnostic/service.go
+++ b/services/diagnostic/service.go
@@ -255,6 +255,12 @@ func (s *Service) NewSensuHandler() *SensuHandler {
 	}
 }
 
+func (s *Service) NewSensuGoHandler() *SensuGoHandler {
+	return &SensuGoHandler{
+		l: s.Logger.With(String("service", "sensugo")),
+	}
+}
+
 func (s *Service) NewSNMPTrapHandler() *SNMPTrapHandler {
 	return &SNMPTrapHandler{
 		l: s.Logger.With(String("service", "snmp")),

--- a/services/sensugo/config.go
+++ b/services/sensugo/config.go
@@ -1,0 +1,27 @@
+package sensugo
+
+import "errors"
+
+type Config struct {
+	// Whether Sensu integration is enabled.
+	Enabled bool `toml:"enabled" override:"enabled"`
+	// The Sensu client host:port address.
+	URL string `toml:"url" override:"url"`
+	// Sensu Go token
+	Token string `toml:"token" override:"token"`
+	// Default Sensu Go namespace
+	Namespace string `toml:"namespace" override:"namespace"`
+	// The sensu handlers to use
+	Handlers []string `toml:"handlers" override:"handlers"`
+}
+
+func NewConfig() Config {
+	return Config{}
+}
+
+func (c Config) Validate() error {
+	if c.Enabled && c.URL == "" {
+		return errors.New("must specify backend URL")
+	}
+	return nil
+}

--- a/services/sensugo/service.go
+++ b/services/sensugo/service.go
@@ -1,0 +1,251 @@
+package sensugo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/influxdata/kapacitor/alert"
+	"github.com/influxdata/kapacitor/keyvalue"
+)
+
+type Diagnostic interface {
+	WithContext(ctx ...keyvalue.T) Diagnostic
+	Error(msg string, err error, kvs ...keyvalue.T)
+}
+
+type Service struct {
+	configValue atomic.Value
+	diag        Diagnostic
+}
+
+func NewService(c Config, d Diagnostic) *Service {
+	s := &Service{
+		diag: d,
+	}
+	s.configValue.Store(c)
+	return s
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+
+func (s *Service) Close() error {
+	return nil
+}
+
+func (s *Service) config() Config {
+	return s.configValue.Load().(Config)
+}
+
+func (s *Service) Update(newConfig []interface{}) error {
+	if l := len(newConfig); l != 1 {
+		return fmt.Errorf("expected only one new config object, got %d", l)
+	}
+	if c, ok := newConfig[0].(Config); !ok {
+		return fmt.Errorf("expected config object to be of type %T, got %T", c, newConfig[0])
+	} else {
+		s.configValue.Store(c)
+	}
+	return nil
+}
+
+type testOptions struct {
+	Check     string            `json:"check"`
+	Entity    string            `json:"entity"`
+	Message   string            `json:"message"`
+	Namespace string            `json:"namespace"`
+	Handlers  []string          `json:"handlers"`
+	Labels    map[string]string `json:"labels"`
+	Level     alert.Level       `json:"level"`
+}
+
+func (s *Service) TestOptions() interface{} {
+	return &testOptions{
+		Check:     "testName",
+		Entity:    "testEntity",
+		Message:   "testMessage",
+		Namespace: "test",
+		Handlers:  []string{},
+		Labels:    make(map[string]string),
+		Level:     alert.Critical,
+	}
+}
+
+func (s *Service) Test(options interface{}) error {
+	o, ok := options.(*testOptions)
+	if !ok {
+		return fmt.Errorf("unexpected options type %T", options)
+	}
+	return s.Alert(
+		o.Check,
+		o.Entity,
+		o.Message,
+		o.Namespace,
+		o.Handlers,
+		o.Labels,
+		o.Level,
+	)
+}
+
+func (s *Service) Alert(check, entity, message, namespace string, handlers []string, labels map[string]string, level alert.Level) error {
+	c := s.config()
+
+	if !c.Enabled {
+		return errors.New("service is not enabled")
+	}
+
+	var status int
+	switch level {
+	case alert.OK:
+		status = 0
+	case alert.Info:
+		status = 0
+	case alert.Warning:
+		status = 1
+	case alert.Critical:
+		status = 2
+	default:
+		status = 3
+	}
+
+	now := time.Now()
+
+	event := &PostEvent{}
+
+	event.Entity.EntityClass = "proxy"
+	event.Entity.Metadata.Name = entity
+
+	if namespace != "" {
+		event.Entity.Metadata.Namespace = namespace
+	} else {
+		event.Entity.Metadata.Namespace = c.Namespace
+	}
+	event.Entity.Metadata.Labels = labels
+	event.Check.Output = message
+	event.Check.Status = status
+	event.Check.Metadata.Name = check
+	event.Check.Metadata.Labels = labels
+	event.Check.Issued = now.Unix()
+	event.Check.Executed = now.Unix()
+
+	if len(handlers) > 0 {
+		event.Check.Handlers = handlers
+	} else {
+		event.Check.Handlers = c.Handlers
+	}
+
+	data, err := json.Marshal(event)
+
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", c.URL, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("failed to create POST request: %v", err)
+	}
+
+	req.Header.Set("Authorization", c.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	ctx, cancel := context.WithTimeout(req.Context(), 1*time.Minute)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	httpClient := &http.Client{}
+
+	resp, err := httpClient.Do(req)
+
+	if err != nil {
+		s.diag.Error("Failed to POST to Sensu Go", err)
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		s.diag.Error(fmt.Sprintf("POST returned non 2xx status code (%d)", resp.StatusCode), err, keyvalue.KV("code", strconv.Itoa(resp.StatusCode)))
+	}
+
+	return nil
+}
+
+type HandlerConfig struct {
+	// Sensu-go backend URL for which to post messages.
+	// If empty uses the address from the configuration.
+	URL string `mapstructure:"url"`
+
+	Namespace string `mapstructure:"namespace"`
+
+	// Metadata labels is a map of key value data to include on the sensu API request.
+	Labels map[string]string `mapstructure:"labels"`
+
+	// Sensu handler list
+	// If empty uses the handler list from the configuration
+	Handlers []string `mapstructure:"handlers"`
+
+	// Check name in metadata
+	Check string `mapstructure:"check"`
+
+	// Entity name in metadata
+	Entity string `mapstructure:"entity"`
+}
+
+// Event that is sent over HTTP POST request to sensu-go backend
+type PostEvent struct {
+	Entity struct {
+		EntityClass string `json:"entity_class"`
+		Metadata    struct {
+			Name      string            `json:"name"`
+			Namespace string            `json:"namespace"`
+			Labels    map[string]string `json:"labels"`
+		} `json:"metadata"`
+	} `json:"entity"`
+	Check struct {
+		Output   string `json:"output"`
+		Status   int    `json:"status"`
+		Metadata struct {
+			Name   string            `json:"name"`
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Issued   int64    `json:"issued"`
+		Executed int64    `json:"executed"`
+		Handlers []string `json:"handlers"`
+	} `json:"check"`
+}
+
+type handler struct {
+	s    *Service
+	c    HandlerConfig
+	diag Diagnostic
+}
+
+func (s *Service) Handler(c HandlerConfig, ctx ...keyvalue.T) (alert.Handler, error) {
+	return &handler{
+		s:    s,
+		c:    c,
+		diag: s.diag.WithContext(ctx...),
+	}, nil
+}
+
+func (h *handler) Handle(event alert.Event) {
+	if err := h.s.Alert(
+		event.State.ID,
+		h.c.Entity,
+		event.State.Message,
+		h.c.Namespace,
+		h.c.Handlers,
+		h.c.Labels,
+		event.State.Level,
+	); err != nil {
+		h.diag.Error("failed to send event to Sensu Go", err)
+	}
+}

--- a/task_master.go
+++ b/task_master.go
@@ -32,6 +32,7 @@ import (
 	"github.com/influxdata/kapacitor/services/pagerduty2"
 	"github.com/influxdata/kapacitor/services/pushover"
 	"github.com/influxdata/kapacitor/services/sensu"
+	"github.com/influxdata/kapacitor/services/sensugo"
 	"github.com/influxdata/kapacitor/services/sideload"
 	"github.com/influxdata/kapacitor/services/slack"
 	"github.com/influxdata/kapacitor/services/smtp"
@@ -177,6 +178,9 @@ type TaskMaster struct {
 	SensuService interface {
 		Handler(sensu.HandlerConfig, ...keyvalue.T) (alert.Handler, error)
 	}
+	SensuGoService interface {
+		Handler(sensugo.HandlerConfig, ...keyvalue.T) (alert.Handler, error)
+	}
 	TalkService interface {
 		Handler(...keyvalue.T) alert.Handler
 	}
@@ -285,6 +289,7 @@ func (tm *TaskMaster) New(id string) *TaskMaster {
 	n.HipChatService = tm.HipChatService
 	n.AlertaService = tm.AlertaService
 	n.SensuService = tm.SensuService
+	n.SensuGoService = tm.SensuGoService
 	n.TalkService = tm.TalkService
 	n.TimingService = tm.TimingService
 	n.K8sService = tm.K8sService


### PR DESCRIPTION
Allows sending events to Sensu Go. The old Sensu handler is not compatible
with Sensu Go.

Example kapacitor.conf:

```[sensugo]
  enabled = true
  url = "https://sensugo.local.domain:8080/api/core/v2/namespaces/default/events"
  namespace = "default"
  handlers = ["sns","slack"]
  token = "Key 45f84411-051e-40ec-aadc-f8acf117882e"
```

Example TICKscript to check telegraf cpu metrics:

```dbrp "telegraf"."default"

var period = 1m
var every = 10s

var processed = stream
  |from()
    .database('telegraf')
    .measurement('cpu')
  |alert()
    .id('{{ index .Tags "host" }}/test')
    .warn(lambda: "usage_idle" < 70.0)
    .sensuGo()
      .handlers('test_alert')
      .label('env','test')
```

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
